### PR TITLE
Support custom project subdirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Created using s2i [v1.1.7](https://github.com/openshift/source-to-image/releases
 
 Create the s2i image with
 
-`#! SBT_VERSION=0.13.16 SCALA_VERSION=2.12.3 make`
+`#! SBT_VERSION=1.2.8 SCALA_VERSION=2.12.8 make`
 
 ### invoke
 
@@ -19,11 +19,12 @@ build an image tagged as `image-name`
 ### configuration
 
 - `SBT_SUBPROJECT`; optional string that specifies the sbt subproject to build in (not needed if not multi-project)
+- `SBT_SUBPROJECT_DIR`; optional string that specifies the sbt subproject directory to build in (not needed if not multi-project)
 - `plugins.sbt`; contains default set of sbt plugins that will be cached during the image build
 
 ### OpenShift Imagestream
 
-An OpenShift Imagestream is provided that can be used in the OpenSHift console to build applications using this s2i image. To use it, simply add it as follows:
+An OpenShift Imagestream is provided that can be used in the OpenShift console to build applications using this s2i image. To use it, simply add it as follows:
 
 ```
 oc create -f sbt.yml

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.7

--- a/s2i/bin/assemble
+++ b/s2i/bin/assemble
@@ -8,8 +8,10 @@
 #
 
 # SBT_SUBPROJECT provides multi project support
+
+: ${SBT_SUBPROJECT_DIR:=$SBT_SUBPROJECT}
 readonly sbt_stage_cmd="${SBT_SUBPROJECT:+${SBT_SUBPROJECT}/}stage"
-readonly sbt_target_dir="${SBT_SUBPROJECT:+${SBT_SUBPROJECT}/}target"
+readonly sbt_target_dir="${SBT_SUBPROJECT_DIR:+${SBT_SUBPROJECT_DIR}/}target"
 
 # If the 'sbt-s2i' assemble script is executed with the '-h' flag, print the usage.
 if [[ "$1" == "-h" ]]; then

--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -9,8 +9,9 @@
 # https://superuser.com/a/38982 for find
 #
 
-readonly sbt_run_cmd="${SBT_SUBPROJECT:+${SBT_SUBPROJECT}/}run"
-readonly sbt_target_dir="${SBT_SUBPROJECT:+${SBT_SUBPROJECT}/}target"
+: ${SBT_SUBPROJECT_DIR:=$SBT_SUBPROJECT}
+readonly sbt_stage_cmd="${SBT_SUBPROJECT:+${SBT_SUBPROJECT}/}stage"
+readonly sbt_target_dir="${SBT_SUBPROJECT_DIR:+${SBT_SUBPROJECT_DIR}/}target"
 readonly staging_path="universal/stage/bin"
 
 readonly execable_count=$(find ${sbt_target_dir}/${staging_path} -executable -type f | wc -l)

--- a/s2i/bin/usage
+++ b/s2i/bin/usage
@@ -7,7 +7,8 @@ Sample invocation:
 
 s2i build <source code path/URL> sbt-s2i <application image>
 
-The build will need configured with SBT_SUBPROJECT if it is a multi-module build
+The build will need configured with SBT_SUBPROJECT if it is a multi-module build and SBT_SUBPROJECT_DIR if the
+name of the subproject and the directory it lives in are different
 
 You can then run the resulting image via:
 docker run <application image>

--- a/sbt.yml
+++ b/sbt.yml
@@ -18,14 +18,14 @@ spec:
       openshift.io/display-name: SBT
       openshift.io/provider-display-name: https://github.com/jw3/sbt-s2i
       sampleRepo: https://github.com/theiterators/akka-http-microservice
-      supports: sbt:2.12.7,java,scala
+      supports: sbt:2.12.8,java,scala
       tags: builder,java,scala
-      version: "2.12.7"
+      version: "2.12.8"
     from:
       kind: DockerImage
-      name: jwiii/sbt-s2i:1.2.3-2.12.7
+      name: mlangc/sbt-s2i:sbt-1.2.8-2.12.8-0.0.1
     generation: 1
     importPolicy: {}
-    name: "2.12.7"
+    name: "2.12.8"
     referencePolicy:
       type: Source

--- a/template.yml
+++ b/template.yml
@@ -40,7 +40,12 @@ parameters:
 
   - name: SUBPROJECT
     displayName: Subproject
-    description: Name of subdirectory in multi-project SBT builds.
+    description: Name subproject in multi-project SBT builds.
+    required: false
+
+  - name: SUBPROJECT_DIR
+    displayName: Subproject
+    description: Name of subproject directory in multi-project SBT builds (defaults to SUBPROJECT).
     required: false
 
 objects:
@@ -70,6 +75,8 @@ objects:
           env:
             - name: SBT_SUBPROJECT
               value: ${SUBPROJECT}
+            - name: SBT_SUBPROJECT_PATH
+              value: ${SUBPROJECT_PATH}
       output:
         to:
           kind: ImageStreamTag


### PR DESCRIPTION
This PR adapts the scripts to support an optional `SBT_SUBPROJECT_DIR` environment variable, that can be used to override the subdirectory of the subproject that should be build. This is needed for builds where subproject names and subproject directories are not identical. A demo project can be found here: https://github.com/mlangc/sbt-s2i-multi-module-demo

Note that this PR overwrites the image name in `sbt.yml`, which is probably not what you want. Just let me know what you want to put there, so that I can adapt value.